### PR TITLE
Free traits from type constraints

### DIFF
--- a/modules/benchmarks/src/main/scala/alleles/bench/Compare.scala
+++ b/modules/benchmarks/src/main/scala/alleles/bench/Compare.scala
@@ -36,15 +36,16 @@ object Compare extends App {
   val options = Epic(initialPop, operators)
   val iterations = 5
 
+  val ga = GeneticAlgorithm[Permutation]
   val comparison = new LongRunningComparison[Permutation, Unit] {
-    def candidates: List[(String, Setting)] = List(
-      "Basic sync" -> GeneticAlgorithm,
-      "Fully parallel" -> GeneticAlgorithm.par,
-      "Parallel #2" -> GeneticAlgorithm.par(new ExecutionContextTaskSupport(ExecutionContext.fromExecutor(Executors.newFixedThreadPool(2)))),
-      "Parallel #4" -> GeneticAlgorithm.par(new ExecutionContextTaskSupport(ExecutionContext.fromExecutor(Executors.newFixedThreadPool(4)))),
-      "Parallel #8" -> GeneticAlgorithm.par(new ExecutionContextTaskSupport(ExecutionContext.fromExecutor(Executors.newFixedThreadPool(8)))),
-      "Parallel #16" -> GeneticAlgorithm.par(new ExecutionContextTaskSupport(ExecutionContext.fromExecutor(Executors.newFixedThreadPool(16)))),
-      "Parallel #32" -> GeneticAlgorithm.par(new ExecutionContextTaskSupport(ExecutionContext.fromExecutor(Executors.newFixedThreadPool(32))))
+    def candidates: List[(String, Setting[Permutation])] = List(
+      "Basic sync" -> ga,
+      "Fully parallel" -> ga.par,
+      "Parallel #2" -> ga.par(new ExecutionContextTaskSupport(ExecutionContext.fromExecutor(Executors.newFixedThreadPool(2)))),
+      "Parallel #4" -> ga.par(new ExecutionContextTaskSupport(ExecutionContext.fromExecutor(Executors.newFixedThreadPool(4)))),
+      "Parallel #8" -> ga.par(new ExecutionContextTaskSupport(ExecutionContext.fromExecutor(Executors.newFixedThreadPool(8)))),
+      "Parallel #16" -> ga.par(new ExecutionContextTaskSupport(ExecutionContext.fromExecutor(Executors.newFixedThreadPool(16)))),
+      "Parallel #32" -> ga.par(new ExecutionContextTaskSupport(ExecutionContext.fromExecutor(Executors.newFixedThreadPool(32))))
     )
 
     val preferences: EvolutionPreferences[Permutation] = EvolutionPreferences(options, iterations)

--- a/modules/benchmarks/src/main/scala/alleles/bench/LongRunningComparison.scala
+++ b/modules/benchmarks/src/main/scala/alleles/bench/LongRunningComparison.scala
@@ -13,7 +13,7 @@ import scala.concurrent.duration._
 
 trait LongRunningComparison[A, B] extends Measuring {
 
-  def candidates: List[(String, Setting)]
+  def candidates: List[(String, Setting[A])]
 
   val preferences: EvolutionPreferences[A]
 

--- a/modules/core/src/main/scala/alleles/environment/Ambience.scala
+++ b/modules/core/src/main/scala/alleles/environment/Ambience.scala
@@ -1,12 +1,11 @@
 package alleles.environment
 
 import alleles.Population
-import alleles.genotype.{Fitness, Join, Variation}
 
 /**
   * Representation of the environment, allowing the population of arbitrary individuals
   * to evolve within a set of genetic operators in a stream of adjusting populations
   */
-trait Ambience {
-  def evolve[A: Fitness : Join : Variation](epic: Epic[A]): EvolutionFlow[Population[A]]
+trait Ambience[A] {
+  def evolve(epic: Epic[A]): EvolutionFlow[Population[A]]
 }

--- a/modules/core/src/main/scala/alleles/environment/FitnessRanking.scala
+++ b/modules/core/src/main/scala/alleles/environment/FitnessRanking.scala
@@ -1,0 +1,15 @@
+package alleles.environment
+
+import alleles.Population
+import alleles.genotype.Fitness
+import alleles.genotype.Fitness.Rated
+import cats.Functor
+
+/**
+  * Applies traversing strategy in `populationFunctor` to calculate
+  * fitness value to each individual in population
+  */
+class FitnessRanking[A: Fitness](populationFunctor: Functor[Population]) extends Ranking[A] {
+  def rate(population: Population[A]): Population[Rated[A]] =
+    populationFunctor.map(population)(a => a -> Fitness(a))
+}

--- a/modules/core/src/main/scala/alleles/environment/GeneticAlgorithm.scala
+++ b/modules/core/src/main/scala/alleles/environment/GeneticAlgorithm.scala
@@ -13,15 +13,15 @@ import scala.collection.parallel.TaskSupport
   *
   * May be used as default implementation of `Ambience`.
   */
-class GeneticAlgorithm[A: Fitness : Join : Variation] extends Setting[A](SeqRanking, SeqProgress) {
-  def par: Setting[A] = new Setting(ParallelRanking, ParallelProgress)
+class GeneticAlgorithm[A: Fitness : Join : Variation] extends Setting[A](new SeqRanking[A], SeqProgress) {
+  def par: Setting[A] = new Setting(new ParallelRanking, ParallelProgress)
 
   def par(taskSupport: TaskSupport): Setting[A] =
     new Setting(
       new ConfigurableParRanking(taskSupport),
       new ConfigurableParProgress(taskSupport))
 
-  def parFitness: Setting[A] = new Setting(ParallelRanking, SeqProgress)
+  def parFitness: Setting[A] = new Setting(new ParallelRanking, SeqProgress)
 }
 
 object GeneticAlgorithm {

--- a/modules/core/src/main/scala/alleles/environment/GeneticAlgorithm.scala
+++ b/modules/core/src/main/scala/alleles/environment/GeneticAlgorithm.scala
@@ -13,15 +13,15 @@ import scala.collection.parallel.TaskSupport
   *
   * May be used as default implementation of `Ambience`.
   */
-class GeneticAlgorithm[A: Fitness : Join : Variation] extends Setting[A](new SeqRanking[A], SeqProgress) {
-  def par: Setting[A] = new Setting(new ParallelRanking, ParallelProgress)
+class GeneticAlgorithm[A: Fitness : Join : Variation] extends Setting[A](new SeqRanking, new SeqProgress) {
+  def par: Setting[A] = new Setting(new ParallelRanking, new ParallelProgress)
 
   def par(taskSupport: TaskSupport): Setting[A] =
     new Setting(
       new ConfigurableParRanking(taskSupport),
       new ConfigurableParProgress(taskSupport))
 
-  def parFitness: Setting[A] = new Setting(new ParallelRanking, SeqProgress)
+  def parFitness: Setting[A] = new Setting(new ParallelRanking, new SeqProgress)
 }
 
 object GeneticAlgorithm {

--- a/modules/core/src/main/scala/alleles/environment/GeneticAlgorithm.scala
+++ b/modules/core/src/main/scala/alleles/environment/GeneticAlgorithm.scala
@@ -3,6 +3,7 @@ package alleles.environment
 import alleles.environment.parallel.configurable.{ConfigurableParProgress, ConfigurableParRanking}
 import alleles.environment.parallel.{ParallelProgress, ParallelRanking}
 import alleles.environment.sequential.{SeqProgress, SeqRanking}
+import alleles.genotype.{Fitness, Join, Variation}
 
 import scala.collection.parallel.TaskSupport
 
@@ -12,13 +13,17 @@ import scala.collection.parallel.TaskSupport
   *
   * May be used as default implementation of `Ambience`.
   */
-object GeneticAlgorithm extends Setting(SeqRanking, SeqProgress) {
-  def par: Setting = new Setting(ParallelRanking, ParallelProgress)
+class GeneticAlgorithm[A: Fitness : Join : Variation] extends Setting[A](SeqRanking, SeqProgress) {
+  def par: Setting[A] = new Setting(ParallelRanking, ParallelProgress)
 
-  def par(taskSupport: TaskSupport): Setting =
+  def par(taskSupport: TaskSupport): Setting[A] =
     new Setting(
       new ConfigurableParRanking(taskSupport),
       new ConfigurableParProgress(taskSupport))
 
-  def parFitness: Setting = new Setting(ParallelRanking, SeqProgress)
+  def parFitness: Setting[A] = new Setting(ParallelRanking, SeqProgress)
+}
+
+object GeneticAlgorithm {
+  def apply[A: Fitness : Join : Variation]: GeneticAlgorithm[A] = new GeneticAlgorithm[A]
 }

--- a/modules/core/src/main/scala/alleles/environment/Progress.scala
+++ b/modules/core/src/main/scala/alleles/environment/Progress.scala
@@ -1,14 +1,12 @@
 package alleles.environment
 
 import alleles.genotype.Fitness.Rated
-import alleles.genotype._
 import alleles.{Epoch, Population}
 
 /**
   * Abstract representation of applying genetic operators to
   * the population of individuals with corresponding fitness values
   */
-trait Progress {
-  def nextGeneration[A: Join : Variation](ratedPop: Population[Rated[A]],
-                                          operators: Epoch[A]): Population[A]
+trait Progress[A] {
+  def nextGeneration(ratedPop: Population[Rated[A]], operators: Epoch[A]): Population[A]
 }

--- a/modules/core/src/main/scala/alleles/environment/Ranking.scala
+++ b/modules/core/src/main/scala/alleles/environment/Ranking.scala
@@ -1,15 +1,8 @@
 package alleles.environment
 
 import alleles.Population
-import alleles.genotype.Fitness
 import alleles.genotype.Fitness.Rated
-import cats.Functor
 
-/**
-  * Applies traversing strategy in `populationFunctor` to calculate
-  * fitness value to each individual in population
-  */
-class Ranking(populationFunctor: Functor[Population]) {
-  def rate[A: Fitness](population: Population[A]): Population[Rated[A]] =
-    populationFunctor.map(population)(a => a -> Fitness(a))
+trait Ranking[A] {
+  def rate(population: Population[A]): Population[Rated[A]]
 }

--- a/modules/core/src/main/scala/alleles/environment/Setting.scala
+++ b/modules/core/src/main/scala/alleles/environment/Setting.scala
@@ -12,7 +12,7 @@ import scala.concurrent.ExecutionContext
   * Implementation of evolution environment, which represents genetic algorithm,
   * with parametrized way of rating the population and applying genetic operators to it
   */
-class Setting[A: Fitness : Join : Variation](ranking: Ranking, flow: Progress) extends Ambience[A] {
+class Setting[A: Fitness : Join : Variation](ranking: Ranking[A], flow: Progress) extends Ambience[A] {
   def evolve(epic: Epic[A]): EvolutionFlow[Population[A]] =
     Source.repeat(()).scan(epic.initialPopulation) {
       case (prev, _) => flow.nextGeneration(ranking.rate(prev), epic.operators)
@@ -22,7 +22,7 @@ class Setting[A: Fitness : Join : Variation](ranking: Ranking, flow: Progress) e
     * Decorates itself with the ability to track the best individual
     * among the whole evolution process
     */
-  def bestTracking: BestTrackingSetting = new BestTrackingSetting(ranking, flow)
+  def bestTracking: BestTrackingSetting[A] = new BestTrackingSetting[A](ranking, flow)
 
   /**
     * Decorates itself with the ability to calculate fitness value

--- a/modules/core/src/main/scala/alleles/environment/Setting.scala
+++ b/modules/core/src/main/scala/alleles/environment/Setting.scala
@@ -2,7 +2,7 @@ package alleles.environment
 
 import akka.stream.scaladsl.Source
 import alleles.Population
-import alleles.environment.async.AsyncSetting
+import alleles.environment.async.{AsyncFitness, AsyncSetting}
 import alleles.environment.bestTracking.BestTrackingSetting
 import alleles.genotype.{Fitness, Join, Variation}
 
@@ -28,5 +28,6 @@ class Setting[A: Fitness : Join : Variation](ranking: Ranking, flow: Progress) e
     * Decorates itself with the ability to calculate fitness value
     * of individuals asynchronously
     */
-  def async(implicit executionContext: ExecutionContext): AsyncSetting = new AsyncSetting(flow)
+  def async(implicit asyncFitness: AsyncFitness[A], executionContext: ExecutionContext): Ambience[A] =
+    new AsyncSetting(flow)
 }

--- a/modules/core/src/main/scala/alleles/environment/Setting.scala
+++ b/modules/core/src/main/scala/alleles/environment/Setting.scala
@@ -12,7 +12,7 @@ import scala.concurrent.ExecutionContext
   * Implementation of evolution environment, which represents genetic algorithm,
   * with parametrized way of rating the population and applying genetic operators to it
   */
-class Setting[A: Fitness : Join : Variation](ranking: Ranking[A], flow: Progress) extends Ambience[A] {
+class Setting[A: Fitness : Join : Variation](ranking: Ranking[A], flow: Progress[A]) extends Ambience[A] {
   def evolve(epic: Epic[A]): EvolutionFlow[Population[A]] =
     Source.repeat(()).scan(epic.initialPopulation) {
       case (prev, _) => flow.nextGeneration(ranking.rate(prev), epic.operators)

--- a/modules/core/src/main/scala/alleles/environment/Setting.scala
+++ b/modules/core/src/main/scala/alleles/environment/Setting.scala
@@ -12,8 +12,8 @@ import scala.concurrent.ExecutionContext
   * Implementation of evolution environment, which represents genetic algorithm,
   * with parametrized way of rating the population and applying genetic operators to it
   */
-class Setting(ranking: Ranking, flow: Progress) extends Ambience {
-  def evolve[A: Fitness : Join : Variation](epic: Epic[A]): EvolutionFlow[Population[A]] =
+class Setting[A: Fitness : Join : Variation](ranking: Ranking, flow: Progress) extends Ambience[A] {
+  def evolve(epic: Epic[A]): EvolutionFlow[Population[A]] =
     Source.repeat(()).scan(epic.initialPopulation) {
       case (prev, _) => flow.nextGeneration(ranking.rate(prev), epic.operators)
     }

--- a/modules/core/src/main/scala/alleles/environment/async/AsyncSetting.scala
+++ b/modules/core/src/main/scala/alleles/environment/async/AsyncSetting.scala
@@ -11,7 +11,7 @@ import scala.concurrent.{ExecutionContext, Future}
   * Implementation of genetic algorithm with asynchronous fitness value computation and
   * parametrized of applying genetic operators to populations
   */
-class AsyncSetting[A](flow: Progress)(implicit executionContext: ExecutionContext,
+class AsyncSetting[A](flow: Progress[A])(implicit executionContext: ExecutionContext,
                                       F: AsyncFitness[A],
                                       J: Join[A],
                                       V: Variation[A]) extends Ambience[A] {

--- a/modules/core/src/main/scala/alleles/environment/async/AsyncSetting.scala
+++ b/modules/core/src/main/scala/alleles/environment/async/AsyncSetting.scala
@@ -1,9 +1,9 @@
 package alleles.environment.async
 
 import akka.stream.scaladsl.Source
-import alleles.environment.{EvolutionFlow, Progress}
+import alleles.Population
+import alleles.environment.{Ambience, Epic, EvolutionFlow, Progress}
 import alleles.genotype.{Join, Variation}
-import alleles.{Epoch, Population}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -11,16 +11,19 @@ import scala.concurrent.{ExecutionContext, Future}
   * Implementation of genetic algorithm with asynchronous fitness value computation and
   * parametrized of applying genetic operators to populations
   */
-class AsyncSetting(flow: Progress)(implicit executionContext: ExecutionContext) {
-  def evolve[A: AsyncFitness : Join : Variation](initial: Population[A],
-                                                 operators: Epoch[A]): EvolutionFlow[Population[A]] = {
-    Source.repeat(()).scanAsync(initial) {
+class AsyncSetting[A](flow: Progress)(implicit executionContext: ExecutionContext,
+                                      F: AsyncFitness[A],
+                                      J: Join[A],
+                                      V: Variation[A]) extends Ambience[A] {
+
+  def evolve(epic: Epic[A]): EvolutionFlow[Population[A]] = {
+    Source.repeat(()).scanAsync(epic.initialPopulation) {
       case (prev, _) => Future.traverse(prev) { g =>
         for {
           individual <- Future.successful(g)
           fitness <- AsyncFitness(g)
         } yield (individual, fitness)
-      }.map(flow.nextGeneration(_, operators))
+      }.map(flow.nextGeneration(_, epic.operators))
     }
   }
 }

--- a/modules/core/src/main/scala/alleles/environment/bestTracking/BestTrackingSetting.scala
+++ b/modules/core/src/main/scala/alleles/environment/bestTracking/BestTrackingSetting.scala
@@ -10,8 +10,7 @@ import alleles.{Epoch, Population}
   * and applying genetic operators to it, capable of keeping track of the best individual
   * through whole evolution with no computation overhead
   */
-class BestTrackingSetting[A: Fitness : Join : Variation](ranking: Ranking[A],
-                                                         flow: Progress) {
+class BestTrackingSetting[A: Fitness : Join : Variation](ranking: Ranking[A], flow: Progress[A]) {
   def evolve(initial: Population[A], operators: Epoch[A]): EvolutionFlow[PopulationWithBest[A]] =
     Source.repeat(()).scan((initial, (initial.head, Double.MaxValue))) {
       case ((prev, prevBest), _) =>

--- a/modules/core/src/main/scala/alleles/environment/bestTracking/BestTrackingSetting.scala
+++ b/modules/core/src/main/scala/alleles/environment/bestTracking/BestTrackingSetting.scala
@@ -10,9 +10,9 @@ import alleles.{Epoch, Population}
   * and applying genetic operators to it, capable of keeping track of the best individual
   * through whole evolution with no computation overhead
   */
-class BestTrackingSetting(ranking: Ranking, flow: Progress) {
-  def evolve[A: Fitness : Join : Variation](initial: Population[A],
-                                            operators: Epoch[A]): EvolutionFlow[PopulationWithBest[A]] =
+class BestTrackingSetting[A: Fitness : Join : Variation](ranking: Ranking[A],
+                                                         flow: Progress) {
+  def evolve(initial: Population[A], operators: Epoch[A]): EvolutionFlow[PopulationWithBest[A]] =
     Source.repeat(()).scan((initial, (initial.head, Double.MaxValue))) {
       case ((prev, prevBest), _) =>
         val ratedPopulation = ranking.rate(prev)

--- a/modules/core/src/main/scala/alleles/environment/parallel/ParallelProgress.scala
+++ b/modules/core/src/main/scala/alleles/environment/parallel/ParallelProgress.scala
@@ -12,15 +12,15 @@ import scala.collection.parallel.immutable.ParVector
   * which applies genetic operators to each individual in parallel
   * using scala parallel collections
   */
-object ParallelProgress extends Progress {
-  def nextGeneration[A: Join : Variation](ratedPop: Population[Rated[A]],
-                                          epoch: Epoch[A]): Population[A] = epoch match {
-    case Epoch(selection, crossover, mutation) =>
-      ParVector.fill(ratedPop.size / 2)(())
-        .map(_ => selection.pair(ratedPop))
-        .flatMap((crossover.pair _).tupled)
-        .map(mutation.single)
-        .seq
-  }
+class ParallelProgress[A: Join : Variation] extends Progress[A] {
+  def nextGeneration(ratedPop: Population[Rated[A]], epoch: Epoch[A]): Population[A] =
+    epoch match {
+      case Epoch(selection, crossover, mutation) =>
+        ParVector.fill(ratedPop.size / 2)(())
+          .map(_ => selection.pair(ratedPop))
+          .flatMap((crossover.pair _).tupled)
+          .map(mutation.single)
+          .seq
+    }
 
 }

--- a/modules/core/src/main/scala/alleles/environment/parallel/ParallelRanking.scala
+++ b/modules/core/src/main/scala/alleles/environment/parallel/ParallelRanking.scala
@@ -1,15 +1,16 @@
 package alleles.environment.parallel
 
 import alleles.Population
-import alleles.environment.Ranking
+import alleles.environment.FitnessRanking
+import alleles.genotype.Fitness
 import cats.Functor
 
 /**
   * Parallel implementation of assigning fitness value for population individuals,
   * using parallel collections
   */
-object ParallelRanking extends {
+class ParallelRanking[A: Fitness] extends {
   private val parallelFunctor: Functor[Population] = new Functor[Population] {
-    def map[A, B](fa: Population[A])(f: A => B): Population[B] = fa.par.map(f).seq
+    def map[I, B](fa: Population[I])(f: I => B): Population[B] = fa.par.map(f).seq
   }
-} with Ranking(parallelFunctor)
+} with FitnessRanking(parallelFunctor)

--- a/modules/core/src/main/scala/alleles/environment/parallel/configurable/ConfigurableParProgress.scala
+++ b/modules/core/src/main/scala/alleles/environment/parallel/configurable/ConfigurableParProgress.scala
@@ -12,9 +12,9 @@ import scala.collection.parallel.immutable.ParVector
   * Parallel implementation of evolution progress,
   * with configurable way of performing parallel computation
   */
-class ConfigurableParProgress(configuration: TaskSupport) extends Progress {
+class ConfigurableParProgress[A: Join : Variation](configuration: TaskSupport) extends Progress[A] {
 
-  def nextGeneration[A: Join : Variation](ratedPop: Population[Rated[A]],
+  def nextGeneration(ratedPop: Population[Rated[A]],
                                           epoch: Epoch[A]): Population[A] = epoch match {
     case Epoch(selection, crossover, mutation) =>
       val base = ParVector.fill(ratedPop.size / 2)(())

--- a/modules/core/src/main/scala/alleles/environment/parallel/configurable/ConfigurableParRanking.scala
+++ b/modules/core/src/main/scala/alleles/environment/parallel/configurable/ConfigurableParRanking.scala
@@ -1,7 +1,8 @@
 package alleles.environment.parallel.configurable
 
 import alleles.Population
-import alleles.environment.Ranking
+import alleles.environment.FitnessRanking
+import alleles.genotype.Fitness
 import cats.Functor
 
 import scala.collection.parallel.TaskSupport
@@ -10,12 +11,12 @@ import scala.collection.parallel.TaskSupport
   * Parallel implementation of assigning fitness value for population individuals,
   * with configurable way of performing parallel computation
   */
-class ConfigurableParRanking(configuration: TaskSupport) extends {
+class ConfigurableParRanking[A: Fitness](configuration: TaskSupport) extends {
   private val parallelFunctor: Functor[Population] = new Functor[Population] {
-    def map[A, B](fa: Population[A])(f: A => B): Population[B] = {
+    def map[I, B](fa: Population[I])(f: I => B): Population[B] = {
       val parPop = fa.par
       parPop.tasksupport = configuration
       parPop.map(f).seq
     }
   }
-} with Ranking(parallelFunctor)
+} with FitnessRanking(parallelFunctor)

--- a/modules/core/src/main/scala/alleles/environment/sequential/SeqProgress.scala
+++ b/modules/core/src/main/scala/alleles/environment/sequential/SeqProgress.scala
@@ -8,10 +8,10 @@ import alleles.{Epoch, Population}
 /**
   * Sequential implementation of evolution progress
   */
-object SeqProgress extends Progress {
-  def nextGeneration[A: Join : Variation](ratedPop: Population[Rated[A]],
-                                          epoch: Epoch[A]): Population[A] = epoch match {
-    case Epoch(selection, crossover, mutation) =>
-      mutation.generation(crossover.generation(selection.generation(ratedPop)))
-  }
+class SeqProgress[A: Join : Variation] extends Progress[A] {
+  def nextGeneration(ratedPop: Population[Rated[A]], epoch: Epoch[A]): Population[A] =
+    epoch match {
+      case Epoch(selection, crossover, mutation) =>
+        mutation.generation(crossover.generation(selection.generation(ratedPop)))
+    }
 }

--- a/modules/core/src/main/scala/alleles/environment/sequential/SeqRanking.scala
+++ b/modules/core/src/main/scala/alleles/environment/sequential/SeqRanking.scala
@@ -1,14 +1,15 @@
 package alleles.environment.sequential
 
 import alleles.Population
-import alleles.environment.Ranking
+import alleles.environment.FitnessRanking
+import alleles.genotype.Fitness
 import cats.Functor
 
 /**
   * Sequential implementation of assigning fitness value to population individuals
   */
-object SeqRanking extends {
+class SeqRanking[A: Fitness] extends {
   private val sequentialFunctor = new Functor[Population] {
-    def map[A, B](fa: Population[A])(f: A => B): Population[B] = fa.map(f)
+    def map[I, O](fa: Population[I])(f: I => O): Population[O] = fa.map(f)
   }
-} with Ranking(sequentialFunctor)
+} with FitnessRanking(sequentialFunctor)

--- a/modules/core/src/main/scala/alleles/environment/sequential/localcached/LocalCacheRanking.scala
+++ b/modules/core/src/main/scala/alleles/environment/sequential/localcached/LocalCacheRanking.scala
@@ -1,18 +1,19 @@
 package alleles.environment.sequential.localcached
 
 import alleles.Population
-import alleles.environment.Ranking
+import alleles.environment.FitnessRanking
+import alleles.genotype.Fitness
 import cats.Functor
 
 /**
   * Sequential implementation of assigning fitness value to population individuals,
   * with memoization of result for the same individuals among single population
   */
-object LocalCacheRanking extends  {
+class LocalCacheRanking[A: Fitness] extends  {
   private val cachedRanking: Functor[Population] = new Functor[Population] {
-    def map[A, B](fa: Population[A])(f: A => B): Population[B] = {
-      val cache = fa.map(x => (x, x)).toMap.mapValues(f)
+    def map[I, B](fa: Population[I])(f: I => B): Population[B] = {
+      val cache = fa.distinct.map(x => (x, f(x))).toMap
       fa.map(cache)
     }
   }
-} with Ranking(cachedRanking)
+} with FitnessRanking(cachedRanking)

--- a/modules/core/src/test/scala/alleles/environment/EvolutionTest.scala
+++ b/modules/core/src/test/scala/alleles/environment/EvolutionTest.scala
@@ -14,16 +14,16 @@ import org.scalacheck.{Gen, Properties}
 import scala.collection.parallel.ForkJoinTaskSupport
 
 object EvolutionTest extends Properties("Evolution strategy props") {
-  val derivative: Gen[Progress] = Gen.oneOf(
-    SeqProgress,
-    ParallelProgress,
+  type Ind = Int
+  val implicits: GenotypeImplicits[Ind] = GenotypeImplicits[Ind]
+
+  import implicits._
+
+  val derivative: Gen[Progress[Ind]] = Gen.oneOf(
+    new SeqProgress,
+    new ParallelProgress,
     new ConfigurableParProgress(new ForkJoinTaskSupport)
   )
-
-  type Ind = Int
-
-  val implicits = GenotypeImplicits[Ind]
-  import implicits._
 
   val populationGen: Gen[Population[Ind]] = nonEmptyListOf(arbInt.arbitrary).map(_.toVector)
 

--- a/modules/core/src/test/scala/alleles/environment/FitnessEvaluatorTest.scala
+++ b/modules/core/src/test/scala/alleles/environment/FitnessEvaluatorTest.scala
@@ -3,6 +3,7 @@ package alleles.environment
 import alleles.environment.parallel.ParallelRanking
 import alleles.environment.parallel.configurable.ConfigurableParRanking
 import alleles.environment.sequential.SeqRanking
+import alleles.genotype.Fitness
 import alleles.genotype.syntax.FitnessObj
 import alleles.{GenotypeImplicits, Population}
 import org.scalacheck.Arbitrary._
@@ -10,18 +11,18 @@ import org.scalacheck.Gen._
 import org.scalacheck.Prop._
 import org.scalacheck.{Gen, Properties}
 
-import scala.collection.parallel.{ForkJoinTaskSupport, TaskSupport}
+import scala.collection.parallel.ForkJoinTaskSupport
 
 
 object FitnessEvaluatorTest extends Properties("Fitness evaluator test") {
-  val derivative: Gen[Ranking] = Gen.oneOf(
-    SeqRanking,
-    ParallelRanking,
+  type Ind = Int
+
+  implicit val fitness: Fitness[Ind] = GenotypeImplicits[Ind].fitness
+  val derivative: Gen[FitnessRanking[Ind]] = Gen.oneOf(
+    new SeqRanking,
+    new ParallelRanking,
     new ConfigurableParRanking(new ForkJoinTaskSupport)
   )
-
-  type Ind = Int
-  implicit val fitness = GenotypeImplicits[Ind].fitness
   val populationGen: Gen[Population[Ind]] = nonEmptyListOf(arbitrary[Ind]).map(_.toVector)
 
   property("Rating population keeps all individuals") = forAll(derivative, populationGen) {

--- a/modules/examples/src/main/scala/alleles/examples/funParamTuning/FunTuningRun.scala
+++ b/modules/examples/src/main/scala/alleles/examples/funParamTuning/FunTuningRun.scala
@@ -55,7 +55,7 @@ object FunTuningRun extends App {
   val operators = Epoch(Selection.tournament(10), CrossoverStrategy.parentsOrOffspring(0.25), MutationStrategy.repetitiveMutation(0.7, 0.4))
 
   val population: Population[Fun] = Await.result(
-    GeneticAlgorithm.evolve(Epic(100, operators)).takeWithin(10 seconds).runWith(Sink.last[Population[Fun]]),
+    GeneticAlgorithm[Fun].evolve(Epic(100, operators)).takeWithin(10 seconds).runWith(Sink.last[Population[Fun]]),
     Duration.Inf)
 
   val best: Fun = population.best

--- a/modules/examples/src/main/scala/alleles/examples/geneticProgramming/Test.scala
+++ b/modules/examples/src/main/scala/alleles/examples/geneticProgramming/Test.scala
@@ -70,7 +70,7 @@ object Test extends App {
     MutationStrategy.repetitiveMutation(0.4, 0.2))
 
   val lastPop: Population[GPTree] = Await.result(
-    GeneticAlgorithm.par.evolve(Epic(100, operators)).take(1000).runWith(Sink.last),
+    GeneticAlgorithm[GPTree] .par.evolve(Epic(100, operators)).take(1000).runWith(Sink.last),
     Duration.Inf)
 
   import alleles.PopulationExtension


### PR DESCRIPTION
The main purpose of this PR is to remove type constraints from traits methods' calls. This means that only concrete implementations will depend on such type class instances as Join or Variation, but they are not demanded by trait declaration.
As a result:
* high-level trait may be implemented ignoring Individual type classes
* fixed implementations (objects) of Ambience, Ranking and Progress are now classes
* AsyncSetting and Setting have a common parent trait